### PR TITLE
add missing backticks to correct formatting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,7 @@ Accepts an AST `object` (as `css.parse` produces) and returns a CSS string.
 var ast = css.parse('body { font-size: 12px; }', { source: 'source.css' });
 
 var css = css.stringify(ast);
+```
 
 ### Errors
 


### PR DESCRIPTION
## Description

Restore backticks inadvertently removed in 24ed6e753fee6f0874446953ed75ae35806ab98c, corrupting the formatting.

## Related Issue

Issues are not available on this repository. :shrug:
