### PR TITLE
Fix regular expression for quoted values in parentheses (+ add test)

### DIFF
--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -313,7 +313,9 @@ export const parse = (
     }
 
     // val
-    const val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^)]*?\)|[^};])+)/);
+    const val = match(
+      /^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|[^)])*?\)|[^};])+)/,
+    );
 
     const ret = pos<CssDeclarationAST>({
       type: CssTypes.declaration,

--- a/test/cases/quoted/ast.json
+++ b/test/cases/quoted/ast.json
@@ -23,6 +23,38 @@
               },
               "source": "input.css"
             }
+          },
+          {
+            "type": "declaration",
+            "property": "background",
+            "value": "url('more stuff); here') 50% 50% no-repeat",
+            "position": {
+              "start": {
+                "line": 3,
+                "column": 3
+              },
+              "end": {
+                "line": 3,
+                "column": 57
+              },
+              "source": "input.css"
+            }
+          },
+          {
+            "type": "declaration",
+            "property": "background",
+            "value": "url(https://example.com/a;b) 50% 50% no-repeat",
+            "position": {
+              "start": {
+                "line": 4,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 61
+              },
+              "source": "input.css"
+            }
           }
         ],
         "position": {
@@ -31,7 +63,7 @@
             "column": 1
           },
           "end": {
-            "line": 3,
+            "line": 5,
             "column": 2
           },
           "source": "input.css"

--- a/test/cases/quoted/compressed.css
+++ b/test/cases/quoted/compressed.css
@@ -1,1 +1,1 @@
-body{background:url('some;stuff;here') 50% 50% no-repeat;}
+body{background:url('some;stuff;here') 50% 50% no-repeat;background:url('more stuff); here') 50% 50% no-repeat;background:url(https://example.com/a;b) 50% 50% no-repeat;}

--- a/test/cases/quoted/input.css
+++ b/test/cases/quoted/input.css
@@ -1,3 +1,5 @@
 body {
   background: url('some;stuff;here') 50% 50% no-repeat;
+  background: url('more stuff); here') 50% 50% no-repeat;
+  background: url(https://example.com/a;b) 50% 50% no-repeat;
 }

--- a/test/cases/quoted/output.css
+++ b/test/cases/quoted/output.css
@@ -1,3 +1,5 @@
 body {
   background: url('some;stuff;here') 50% 50% no-repeat;
+  background: url('more stuff); here') 50% 50% no-repeat;
+  background: url(https://example.com/a;b) 50% 50% no-repeat;
 }


### PR DESCRIPTION
## Description

As explained in the related issue, values with parentheses should allow quoted strings inside where a closing parathesis is part of the string. This wasn't the case with the regex before, and I've added this extra case to the regex. Visualized, here is the before and after:

| Before  | After  |
|---|---|
| ![image (2)](https://github.com/user-attachments/assets/43f2de9d-e162-49be-acb0-f8f2eb7bde5e)  | ![image (1)](https://github.com/user-attachments/assets/f811be16-a70c-4239-a194-ce0c40df69e1)  |

## Related Issue

#399

## Motivation and Context

In some real-world CSS files, such quoted strings contain `)` characters that would cause the parser to crash or read on silently capturing tens of thousands of random CSS bytes as the string value. See the related issue for more details.

## How Has This Been Tested?

2 tests were added to the `quoted` test case:

```css
  background: url('more stuff); here') 50% 50% no-repeat;
  background: url(https://example.com/a;b) 50% 50% no-repeat;
```

The first is for the initial issue, and the second is to make sure semicolons are still allowed within parentheses.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
