### PR TITLE
Release 4.5.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.0] - 2026-05-20
+
+### Added
+- Add support for CSS Nesting — rules nested inside other rules (#621 by @jogibear9988)
+- Add support for `@container` container queries with nested rule body
+- Add support for Page Margin Boxes (`@top-left`, `@bottom-right`, `@left-middle`, etc.) inside `@page`
+- Add generic at-rule fallback — unknown `@foo { ... }` and `@foo ...;` rules are preserved as `CssGenericAtRuleAST` instead of being dropped
+- Add support for `@counter-style`, `@font-feature-values`, `@scope`, `@view-transition`, `@position-try`
+- Export new TypeScript types: `CssGenericAtRuleAST`, `CssPageMarginBoxAST`, `CssPositionTryAST`, `CssScopeAST`, `CssViewTransitionAST`, `CssCounterStyleAST`, `CssFontFeatureValuesAST`
+
+### Fixed
+- Fix selector parsing for complex nested selectors including `:is()`, `:has()`, `:not()`
+- Fix `@page` to correctly accept margin-box at-rule children
+- Fix bracket- and quote-aware position tracking for pseudo-functions
+
+### Changed
+- Upgrade to TypeScript 6.0.2
+- Upgrade to `@rollup/plugin-terser` 1.0.0
+- Drop Node 18 from CI (EOL April 2025) — minimum supported runtime is now Node 20
+
+### Security
+- Update lodash to 4.18.1
+- Update minimatch to 3.1.5
+- Update picomatch to 4.0.4
+
 ## [4.4.4] - 2025-07-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/css-tools",
-  "version": "4.4.4",
+  "version": "4.5.0",
   "description": "A modern CSS parser and stringifier with TypeScript support",
   "source": "src/index.ts",
   "main": "./dist/cjs/adobe-css-tools.cjs",


### PR DESCRIPTION
Description:

# Release 4.5.0: Modern CSS Feature Support

## Description

- Add support for **CSS Nesting** — rules nested inside other rules
- Add support for **Container Queries** (`@container`)
- Add support for **Page Margin Boxes** — `@top-left`, `@bottom-right`, etc. inside `@page`
- Add **generic at-rule fallback** — unknown `@foo { ... }` and `@foo ...;` rules are preserved in the AST as `CssGenericAtRuleAST` instead of being dropped
- Add `@counter-style`, `@font-feature-values`, `@scope`, `@view-transition`, `@position-try`
- Fix selector parsing for complex nested selectors (`:is()`, `:has()`, `:not()`)
- Fix `@page` to correctly accept margin-box children
- Upgrade to TypeScript 6.0.2
- Drop Node 18 from CI (EOL April 2025) — minimum runtime is now Node 20

## Related Issue

Closes #210 (page margin boxes), #158 (CSS nesting)

## Motivation and Context

The parser was silently dropping unknown at-rules and had no support for modern CSS nesting and container query syntax. The new `CssGenericAtRuleAST` fallback ensures unknown rules are round-tripped losslessly.

## How Has This Been Tested?

- 251 new test lines and 18 new test case files covering nesting, container queries, page margin boxes, generic at-rules, and special strings
- All existing tests pass
- Build validated with `@arethetypeswrong/cli` — no export regressions

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.