### PR TITLE
fix: keep comment-like text inside attribute-selector strings

### DIFF
--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -34,6 +34,7 @@ import {
 } from '../type';
 import {
   indexOfArrayWithBracketAndQuoteSupport,
+  removeCommentWithQuoteSupport,
   splitWithBracketAndQuoteSupport,
 } from '../utils/stringSearch';
 
@@ -256,8 +257,8 @@ export const parse = (
     const fakeMatch = [selectorStr] as unknown as RegExpExecArray;
     processMatch(fakeMatch);
 
-    // remove comment in selector;
-    const res = trim(selectorStr).replace(commentRegex, '');
+    // remove comment in selector, but keep comment-like text inside strings;
+    const res = removeCommentWithQuoteSupport(trim(selectorStr));
 
     return splitWithBracketAndQuoteSupport(res, [',']).map((v) => trim(v));
   }

--- a/src/utils/stringSearch.ts
+++ b/src/utils/stringSearch.ts
@@ -172,3 +172,63 @@ export const splitWithBracketAndQuoteSupport = (
   }
   return result;
 };
+
+/**
+ * Remove `/* ... *\/` comments from a string while preserving the content of
+ * quoted strings. A `/*` inside a quoted string does not start a comment, so
+ * comment-like text in an attribute-selector value must be kept verbatim.
+ * @example
+ * ```ts
+ * removeCommentWithQuoteSupport('a /*c*\/ b') // 'a  b'
+ * removeCommentWithQuoteSupport('a[title="/*x*\/"]') // 'a[title="/*x*\/"]'
+ * ```
+ */
+export const removeCommentWithQuoteSupport = (string: string): string => {
+  let result = '';
+  let currentPosition = 0;
+  let maxLoop = MAX_LOOP;
+
+  while (currentPosition < string.length && maxLoop > 0) {
+    const all = [
+      string.indexOf('/*', currentPosition),
+      string.indexOf('"', currentPosition),
+      string.indexOf("'", currentPosition),
+    ].filter((v) => v !== -1);
+
+    if (all.length === 0) {
+      result += string.substring(currentPosition);
+      return result;
+    }
+
+    const firstMatchPos = Math.min(...all);
+    result += string.substring(currentPosition, firstMatchPos);
+    const char = string[firstMatchPos];
+
+    if (char === '/') {
+      const endComment = string.indexOf('*/', firstMatchPos + 2);
+      if (endComment === -1) {
+        return result;
+      }
+      currentPosition = endComment + 2;
+    } else {
+      const endQuotePosition = indexOfArrayNonEscaped(
+        string,
+        [char],
+        firstMatchPos + 1,
+      );
+      if (endQuotePosition === -1) {
+        result += string.substring(firstMatchPos);
+        return result;
+      }
+      result += string.substring(firstMatchPos, endQuotePosition + 1);
+      currentPosition = endQuotePosition + 1;
+    }
+    maxLoop--;
+  }
+
+  if (maxLoop <= 0) {
+    throw new Error('Too many escaping');
+  }
+
+  return result;
+};

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -360,4 +360,54 @@ describe('parse(str)', () => {
       }).toThrow();
     });
   });
+
+  describe('comment-like text inside attribute-selector strings', () => {
+    it('should keep a comment-like attribute value intact', () => {
+      const css = 'a[title="/*x*/"] { color: red; }';
+      const ast = parse(css);
+      const rule = ast.stylesheet.rules[0] as CssRuleAST;
+
+      expect(rule.selectors).toEqual(['a[title="/*x*/"]']);
+    });
+
+    it('should keep comment-like text spliced inside an attribute value', () => {
+      const css = 'a[data="a/*b*/c"] { color: red; }';
+      const ast = parse(css);
+      const rule = ast.stylesheet.rules[0] as CssRuleAST;
+
+      expect(rule.selectors).toEqual(['a[data="a/*b*/c"]']);
+    });
+
+    it('should keep comment-like text inside single-quoted attribute values', () => {
+      const css = "a[data='/*x*/'] { color: red; }";
+      const ast = parse(css);
+      const rule = ast.stylesheet.rules[0] as CssRuleAST;
+
+      expect(rule.selectors).toEqual(["a[data='/*x*/']"]);
+    });
+
+    it('should still strip a real comment that precedes a quoted attribute value', () => {
+      const css = 'a:not(/*x*/.b) { color: red; }';
+      const ast = parse(css);
+      const rule = ast.stylesheet.rules[0] as CssRuleAST;
+
+      expect(rule.selectors).toEqual(['a:not(.b)']);
+    });
+
+    it('should still strip a real comment between two compound selectors', () => {
+      const css = 'a /*c*/ b { color: red; }';
+      const ast = parse(css);
+      const rule = ast.stylesheet.rules[0] as CssRuleAST;
+
+      expect(rule.selectors).toEqual(['a  b']);
+    });
+
+    it('should strip a real comment but keep an adjacent comment-like string', () => {
+      const css = 'a[title="/*x*/"]/*real*/ { color: red; }';
+      const ast = parse(css);
+      const rule = ast.stylesheet.rules[0] as CssRuleAST;
+
+      expect(rule.selectors).toEqual(['a[title="/*x*/"]']);
+    });
+  });
 });


### PR DESCRIPTION
The selector parser strips `/* ... */` from the entire selector string before splitting on commas, without checking for quoted strings. A `/*` that appears inside a quoted attribute value is literal string content, not a comment, so the value is silently destroyed:

```js
const { parse } = require("@adobe/css-tools");

parse('a[title="/*x*/"]{color:red}').stylesheet.rules[0].selectors;
// expected: [ 'a[title="/*x*/"]' ]
// actual:   [ 'a[title=""]' ]        <- attribute value destroyed

parse('a[data="a/*b*/c"]{color:red}').stylesheet.rules[0].selectors;
// expected: [ 'a[data="a/*b*/c"]' ]
// actual:   [ 'a[data="ac"]' ]       <- value spliced, meaning changed
```

This is silent data corruption: the AST holds a different selector than the input, so `stringify(parse(s))` emits a rule that no longer matches the same elements.

## Spec

CSS Syntax Level 3 recognizes comment tokens only at the top level of tokenization. Once a string token has begun (after `"` or `'`), `/*` does not start a comment, so `[title="/*x*/"]` has the literal attribute value `/*x*/`.

## Fix

Add `removeCommentWithQuoteSupport` to the existing `stringSearch` utility, mirroring the quote-aware scanning already used by `indexOfArrayWithBracketAndQuoteSupport` (it reuses `indexOfArrayNonEscaped` to find the matching close quote and respects backslash escapes). `selector()` now calls it instead of the naive `commentRegex` replace.

Real comments outside strings are still stripped, so existing behavior is preserved:

- `a:not(/*x*/.b)` -> `a:not(.b)`
- `a /*c*/ b` -> `a  b`
- `head, /* footer, */body/*, nav */` -> `["head", "body"]` (issue #175 case, still green)

The declaration-value comment strip (`declaration()`) is left untouched.

## Tests

Added a `describe` block in `test/parse.test.ts` covering the corrupted cases (double-quoted, single-quoted, spliced, real-comment-adjacent) plus guard cases that assert real comments are still removed. Full suite: 228 passing, lint clean.
